### PR TITLE
Fix server path: remove capital S

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Complete details about the addon and usage instructions are in the addon [reposi
 
 ## Running the sample Elixir Project
 
-A simple Elixir server is available in [Demo/Server](./Demo/Server).
+A simple Elixir server is available in [Demo/server](./Demo/server).
 
 To run it, have Elixir installed, then:
 ```


### PR DESCRIPTION
This URL 404s: https://github.com/alfredbaudisch/GodotPhoenixChannels-Demo/tree/master/Demo/Server

This one does not: https://github.com/alfredbaudisch/GodotPhoenixChannels-Demo/tree/master/Demo/server

😄 